### PR TITLE
Fix GetEnumValueText field selection (#4)

### DIFF
--- a/Patchwork.Engine/Utility/Reflections and Cecil/ReflectHelper.cs
+++ b/Patchwork.Engine/Utility/Reflections and Cecil/ReflectHelper.cs
@@ -57,7 +57,7 @@ namespace Patchwork.Engine.Utility {
 			if (_enumDescriptions.ContainsKey(boxed)) {
 				return _enumDescriptions[boxed];
 			}
-			var statFields = typeof (T).GetFields(CommonBindingFlags.Everything & BindingFlags.Static);
+			var statFields = typeof (T).GetFields(CommonBindingFlags.Everything & ~BindingFlags.Instance);
 			var attrAndValues =
 				from field in statFields
 				let descAttr = field.GetCustomAttribute<DescriptionAttribute>()


### PR DESCRIPTION
Previously, enum fields were selected with the filter `CommonBindingFlags.Everything & BindingFlags.Static`, which is equivalent to just `BindingFlags.Static`. According to the [docs on Type.GetFields](https://msdn.microsoft.com/en-us/library/aa332470(v=vs.71).aspx), `BindingFlags.Public` needs to be included to select public fields, and likewise `BindingFlags.Private` for private fields.

This change eliminates the `KeyNotFoundException` error message seen in #4